### PR TITLE
Error handling when shutting down the bot

### DIFF
--- a/index.py
+++ b/index.py
@@ -848,5 +848,8 @@ def main():
         sys.stdout.flush()
         time.sleep(general_check_time)
 
-
-main()
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        logger('Shtting down the bot...', True)

--- a/index.py
+++ b/index.py
@@ -852,4 +852,4 @@ if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:
-        logger('Shtting down the bot...', True)
+        logger('Shutting down the bot...', True)


### PR DESCRIPTION
This change will prevent the errors in the console when pressing CTRL + C to shutdown the bot